### PR TITLE
chore: remove trailing slash

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -4,7 +4,7 @@
 
 <div class="w-full justify-center flex flex-row gap-5 top-[5rem] left-12 m-0">
   <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/">Home</a>
-  <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/blog/">Blog</a>
-  <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/about/">About</a>
-  <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/tags/">Tags</a>
+  <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/blog">Blog</a>
+  <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/about">About</a>
+  <a class="block text-center py-3 decoration-[none] text-lg font-medium hover:text-primary" href="/tags">Tags</a>
 </div>


### PR DESCRIPTION
remove trailing slash in navigation